### PR TITLE
[Bugfix] RosgraphMonitor Init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Produced by launch_testing
+__pycache__

--- a/rosgraph_monitor/CMakeLists.txt
+++ b/rosgraph_monitor/CMakeLists.txt
@@ -81,6 +81,9 @@ if(BUILD_TESTING)
   ament_add_gmock(test_graph_monitor test/test_graph_monitor.cpp)
   target_link_libraries(test_graph_monitor
     ${PROJECT_NAME})
+
+  find_package(launch_testing_ament_cmake REQUIRED)
+  add_launch_test(test/test_graph_monitor_launch.py)
 endif()
 
 ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)

--- a/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
+++ b/rosgraph_monitor/include/rosgraph_monitor/monitor.hpp
@@ -111,6 +111,10 @@ public:
 
   virtual ~RosGraphMonitor();
 
+  /// @brief Initialize the monitor and start watching the rosgraph with
+  /// configuration provided in constructor.
+  void init();
+
   /// @brief Return diagnostics of latest graph understanding
   /// @return A message filled with all current conditions. May be empty array, but never nullptr
   std::unique_ptr<diagnostic_msgs::msg::DiagnosticArray> evaluate();

--- a/rosgraph_monitor/src/monitor.cpp
+++ b/rosgraph_monitor/src/monitor.cpp
@@ -97,11 +97,7 @@ RosGraphMonitor::RosGraphMonitor(
   now_fn_(now_fn),
   node_graph_(node_graph),
   logger_(logger),
-  graph_change_event_(node_graph->get_graph_event())
-{
-  update_graph();
-  watch_thread_ = std::thread(std::bind(&RosGraphMonitor::watch_for_updates, this));
-}
+  graph_change_event_(node_graph->get_graph_event()) {}
 
 RosGraphMonitor::~RosGraphMonitor()
 {
@@ -111,6 +107,12 @@ RosGraphMonitor::~RosGraphMonitor()
   node_graph_->notify_shutdown();
   update_event_.set();
   watch_thread_.join();
+}
+
+void RosGraphMonitor::init()
+{
+  update_graph();
+  watch_thread_ = std::thread(std::bind(&RosGraphMonitor::watch_for_updates, this));
 }
 
 void RosGraphMonitor::update_graph()

--- a/rosgraph_monitor/src/node.cpp
+++ b/rosgraph_monitor/src/node.cpp
@@ -4,8 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
+//     http://www.apache.org/licenses/LICENSE-2.0 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -65,10 +64,12 @@ Node::Node(const rclcpp::NodeOptions & options)
 {
   on_new_params();
   graph_analyzer_.init("/Health", params_.graph_analyzer);
+  graph_monitor_.init();
+
   // Don't start evaluation timer until after first configuration of the monitor
   timer_publish_report_ = create_wall_timer(
-      std::chrono::milliseconds(params_.diagnostics_publish_period_ms),
-      std::bind(&Node::publish_diagnostics, this));
+    std::chrono::milliseconds(params_.diagnostics_publish_period_ms),
+    std::bind(&Node::publish_diagnostics, this));
 }
 
 rcl_interfaces::msg::SetParametersResult Node::on_parameter_event(

--- a/rosgraph_monitor/test/test_graph_monitor.cpp
+++ b/rosgraph_monitor/test/test_graph_monitor.cpp
@@ -260,6 +260,7 @@ protected:
 
     auto logger = logger_.get_child("graphmon");
     graphmon_.emplace(node_graph_, [this]() {return now_;}, logger);
+    graphmon_->init();
   }
 
   void trigger_and_wait()

--- a/rosgraph_monitor/test/test_graph_monitor_launch.py
+++ b/rosgraph_monitor/test/test_graph_monitor_launch.py
@@ -1,0 +1,126 @@
+# Copyright 2024 - All Rights Reserved
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+#!/usr/bin/env python3
+
+import pytest
+import unittest
+import time
+
+import rclpy
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch_testing.actions import ReadyToTest
+from rclpy.qos import QoSProfile
+# Import duration
+from rclpy.duration import Duration
+
+
+from std_msgs.msg import Bool
+from diagnostic_msgs.msg import DiagnosticArray
+import threading
+
+
+qos_profile_with_deadline = QoSProfile(
+    depth=10,
+    deadline=Duration(seconds=0, nanoseconds=100000000)
+)
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    # Initialize with default params
+    device_under_test = Node(
+        package='rosgraph_monitor',
+        executable='rosgraph_monitor_node',
+        name='rosgraph_monitor',
+        output='screen',
+        arguments=['--ros-args', '--log-level', 'DEBUG'],
+    )
+
+    context = {'device_under_test': device_under_test}
+    return (LaunchDescription([device_under_test,
+                               ReadyToTest()]),  context)
+
+
+class TestProcessOutput(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Initialize the ROS context for the test node
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Shutdown the ROS context
+        rclpy.shutdown()
+
+    def setUp(self):
+        # Create a ROS node for tests
+        self.diagnostics = []
+        self.diagnostics_agg_msgs = []
+        self.topic_statistics = []
+        self.publisher_node = rclpy.create_node('publisher_node')
+        self.subscriber_node = rclpy.create_node('subscriber_node')
+
+        self.executor = rclpy.executors.MultiThreadedExecutor()
+        self.executor.add_node(self.publisher_node)
+        self.executor.add_node(self.subscriber_node)
+
+        self.dummy_publisher = self.publisher_node.create_publisher(
+            Bool, '/bool_publisher', qos_profile_with_deadline)
+        timer_period = 0.1  # seconds
+        self.publishr_timer = self.publisher_node.create_timer(
+            timer_period, self.publisher_callback)
+
+        self.spin_thread = threading.Thread(target=self.executor.spin)
+        self.spin_thread.start()
+
+    def publisher_callback(self):
+        msg = Bool()
+        msg.data = True
+        self.dummy_publisher.publish(msg)
+
+    def tearDown(self):
+        self.executor.shutdown()
+        self.spin_thread.join()
+        self.subscriber_node.destroy_node()
+        self.publisher_node.destroy_node()
+
+    def test_health_monitor_diagnostics(self):
+        sub = self.subscriber_node.create_subscription(
+            DiagnosticArray,
+            '/diagnostics_agg',
+            lambda msg: self.diagnostics_agg_msgs.append(msg),
+            1)
+
+        end_time = time.time() + 5
+        while time.time() < end_time:
+            rclpy.spin_once(self.publisher_node, timeout_sec=0.1)
+
+        self.subscriber_node.destroy_subscription(sub)
+
+        self.assertGreater(
+            len(self.diagnostics_agg_msgs), 0, "There should be at least one /diagnostics_agg message")
+
+        last_msg = self.diagnostics_agg_msgs[-1]
+
+        self.assertTrue(all([int.from_bytes(status.level, byteorder='big') == 0 for status in last_msg.status]),
+                        "All diagnostic statuses should be healthy")


### PR DESCRIPTION
## Description

In the process of creating some automated tests around `rosgraph_monitor`, I noticed that it was still processing ignored nodes like `/_ros2cli_`. 

Turns out there was a bit of a race condition between when the graph started monitoring nodes and when it started its own monitoring thread.

So I just split out those components into an `init` method.

## Test Plan

Added a launch test to this effect, and updated the effected unit tests.